### PR TITLE
Remove XSLT1.0 option. Does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 validation
 ==========
 
-Contains all files related to validation of the simplerinvoicing xml files.
+Contains all files related to validation of the simplerinvoicing XML files.
 
 The validation is based on Schematron; specified in the file SI-UBL-INV.SCH and SI-UBL-PO.SCH.
 
-An XSLT-file based on the schematron definition is also provided; for
-SI-UBL-1.2 this is currently SI-UBL-INV-1.2.xsl for invoice and SI-UBL-PO-1.2.xsl for purchase order.
+An XSLT 2.0-file based on the schematron definition is also provided; for
+SI-UBL-1.2 this is currently SI-UBL-INV-1.2.xsl for invoice and SI-UBL-PO-1.2.xsl for purchase order. We use XSLT 2.0 instead of XSLT 1.0 for stricter type checking.
 
 You can recreate this XSLT file by running one of the conversion scripts.
-By default the generated XSLT files will be based on XSLT2 but you can create XSLT1 compatible XSLT files by changing the `XSLT_VERSION` in the scripts, e.g. with `XSLT_VERSION=1 ./convert_linux.sh SI-UBL-INV.SCH SI-UBL-INV-1.2.xsl`.
 
 An overview of the applicable rules can be found in rules-overview-invoice.html and rules-overview-po.html
 (generated from the generated XSLT file).

--- a/convert_linux.sh
+++ b/convert_linux.sh
@@ -17,4 +17,4 @@ function do_cmd {
 
 do_cmd java -jar ./lib/saxon9he.jar -o:${CONVERT_BASE}/temp/step1_dsdl.xsl $INPUT_FILE ${CONVERT_BASE}/convert/iso_dsdl_include.xsl &&\
 do_cmd java -jar ./lib/saxon9he.jar -o:${CONVERT_BASE}/temp/step2_abstract.xsl ${CONVERT_BASE}/temp/step1_dsdl.xsl ${CONVERT_BASE}/convert/iso_abstract_expand.xsl &&\
-do_cmd java -jar ./lib/saxon9he.jar -o:${OUTPUT_FILE} ${CONVERT_BASE}/temp/step2_abstract.xsl ${CONVERT_BASE}/convert/iso_svrl_for_xslt${XSLT_VERSION:-2}.xsl
+do_cmd java -jar ./lib/saxon9he.jar -o:${OUTPUT_FILE} ${CONVERT_BASE}/temp/step2_abstract.xsl ${CONVERT_BASE}/convert/iso_svrl_for_xslt2.xsl

--- a/convert_windows.bat
+++ b/convert_windows.bat
@@ -1,6 +1,5 @@
 @set file_name=SI-UBL-INV
 @set convert_base=
-@set xslt_version=2
 
 java -jar ./lib/saxon9he.jar -versionmsg:off -o:%convert_base%temp\%file_name%_step_dsdl.xsl %file_name%.SCH %convert_base%convert\iso_dsdl_include.xsl
 @if not %errorlevel%==0 goto error
@@ -8,7 +7,7 @@ java -jar ./lib/saxon9he.jar -versionmsg:off -o:%convert_base%temp\%file_name%_s
 java -jar ./lib/saxon9he.jar -versionmsg:off -o:%convert_base%temp\%file_name%_step_abstract.xsl %convert_base%temp\%file_name%_step_dsdl.xsl %convert_base%convert\iso_abstract_expand.xsl
 @if not %errorlevel%==0 goto error
 
-java -jar ./lib/saxon9he.jar -versionmsg:off -o:%file_name%.xsl %convert_base%temp\%file_name%_step_abstract.xsl %convert_base%convert\iso_svrl_for_xslt%xslt_version%.xsl
+java -jar ./lib/saxon9he.jar -versionmsg:off -o:%file_name%.xsl %convert_base%temp\%file_name%_step_abstract.xsl %convert_base%convert\iso_svrl_for_xslt2.xsl
 @if not %errorlevel%==0 goto error
 
 @echo Artefact validation XSLT written to %file_name%.xsl


### PR DESCRIPTION
Turns out that the added converter support for XSLT 1.0 is useless. Yes, the converter script can create a XSLT 1.0 compatible structure but the rule conditions themselves as defined in schematron contain XPath 2.0 functions/types (`xs:decimal`) that are not converted. 